### PR TITLE
Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,7 +219,7 @@ Allow clicking a linked actor to open their sheet (also create css for linked ac
 - Fixed bug with message mode update failing entire actions due to socket restrictions.
 - Updated hamon and cyborg descriptions
 
-## [0.9.14.2] - 2026-8-24
+## [0.9.14.3] - 2026-8-24
 - Gambit execution properly extracts the luck move
 - Gambit dialog request is returned to correct sender
 - It has been noted that game.messages.contents.at(-x) can expose any hidden message, overhaul of security considered
@@ -227,6 +227,10 @@ Allow clicking a linked actor to open their sheet (also create css for linked ac
 - Removed access to the reckless button
 - Fixed advantage applying its visibility to first quadrant
 - Fixed gambits not checking if you could afford them
+- Fixed gambit dialog breaking due to async promise within confirmation dialog
+- Fixed being unable to unselect a gambit
+- Began standardized locations of gambit logic
+- Rough patch for gambit warning in getLuckMoveExecutionContext
 
 # What's left? (Ordered By Priority)
 - Setup tests to avoid unexpectedly causing things to stop functioning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,8 +226,11 @@ Allow clicking a linked actor to open their sheet (also create css for linked ac
 - Small patch for error emitted by action on creation
 - Removed access to the reckless button
 - Fixed advantage applying its visibility to first quadrant
+- Fixed gambits not checking if you could afford them
 
 # What's left? (Ordered By Priority)
+- Setup tests to avoid unexpectedly causing things to stop functioning
+- 
 - Give Cyborg a more comfortable upgrade space
 - Switch to V2 framework before V15
 - Implement Learning automation (Once added will set the system to 1.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,14 @@ Allow clicking a linked actor to open their sheet (also create css for linked ac
 - Fixed bug with message mode update failing entire actions due to socket restrictions.
 - Updated hamon and cyborg descriptions
 
+## [0.9.14.2] - 2026-8-24
+- Gambit execution properly extracts the luck move
+- Gambit dialog request is returned to correct sender
+- It has been noted that game.messages.contents.at(-x) can expose any hidden message, overhaul of security considered
+- Small patch for error emitted by action on creation
+- Removed access to the reckless button
+- Fixed advantage applying its visibility to first quadrant
+
 # What's left? (Ordered By Priority)
 - Give Cyborg a more comfortable upgrade space
 - Switch to V2 framework before V15

--- a/modules/apps/bad6-roller.js
+++ b/modules/apps/bad6-roller.js
@@ -19,7 +19,7 @@ let rollerClickTimer = null;
 let lastActionMessageId = null;
 let lastActionMessageAt = 0;
 let chatListenersRegistered = false;
-const DOUBLE_CLICK_WINDOW_MS = 500;
+const DOUBLE_CLICK_WINDOW_MS = 600;
 
 async function executeRollerAsGM(handler, ...args) {
     const socket = getRollerSocket();
@@ -82,6 +82,13 @@ export function rollerControl() {
 }
 
 export async function createActionMessage() { 
+    if (!game.user.isGM) {
+        const socket = getRollerSocket();
+        const msg = await socket.executeAsGM("createActionMessage");
+        if (!msg) {
+            console.log.warn("No GM detected, certain functionality will fail.");
+        } else return msg;
+    }
     const displayMessage = await ChatMessage.create(withCurrentMessageMode({
         content: await renderAction()
     }));
@@ -92,8 +99,12 @@ export async function createActionMessage() {
         }
         , content: await renderSource()
     };
-    ChatMessage.applyMode(messageData, "gm");
-    const sourceMessage = await ChatMessage.create(messageData);
+    const sourceMessage = await ChatMessage.create({
+        speaker: { alias: "Debug Message" },
+        content: await renderSource(),
+        whisper: game.users.filter(u => u.isGM).map(u => u.id),
+        blind: true
+    });
     await sourceMessage.setFlag("bizarre-adventures-d6", "type", "source");
     await sourceMessage.setFlag("bizarre-adventures-d6", "displayId", displayMessage.id);
     await displayMessage.setFlag("bizarre-adventures-d6", "sourceId", sourceMessage.id);
@@ -101,6 +112,13 @@ export async function createActionMessage() {
 }
 
 export async function createContestMessage() {
+    if (!game.user.isGM) {
+        const socket = getRollerSocket();
+        const msg = await socket.executeAsGM("createContestMessage");
+        if (!msg) {
+            console.log.warn("No GM detected, certain functionality will fail.");
+        } else return msg;
+    }
     const action = await createActionMessage();
     const message = await dispatchUpdateToContest(action.id);
     return message;
@@ -211,18 +229,20 @@ export async function registerChatListeners() {
                 currentMessageCount: game.messages?.size ?? 0
             });
         }
-        // switched from renderChatMessage blind - unsure what context is
-        Hooks.on("renderChatMessageHTML", (message, html, context) => {
+
+        // switched from renderChatMessage. context includes entire message content and related info
+        Hooks.on("renderChatMessageHTML", async (message, html, context) => {
             if (isDebugEnabled()) {
                 const root = html?.[0] || html;
                 const actorNameNodes = root?.querySelectorAll?.(".bad6-actor-name")?.length ?? 0;
                 const rollNodes = root?.querySelectorAll?.(".bad6-roll-display[data-quadrant]")?.length ?? 0;
-                console.log("[BAD6][ChatDebug] renderChatMessage fired", {
+                console.log("[BAD6][ChatDebug] renderChatMessageHTML fired", {
                     messageId: message?.id,
                     type: message?.getFlag?.("bizarre-adventures-d6", "type") || null,
                     actorNameNodes,
                     rollNodes,
-                    locked: !!message?.getFlag?.("bizarre-adventures-d6", "Locked")
+                    locked: !!message?.getFlag?.("bizarre-adventures-d6", "Locked"),
+                    context
                 });
             }
             // TODO: Check if privacy related and remove if so
@@ -230,13 +250,20 @@ export async function registerChatListeners() {
             // applyClientRollVisibility(message, html);
             // For our roll messages, re-add client limitation, or hide message entirely if debug is off
             const type = message.getFlag('bizarre-adventures-d6', 'type');
-            if (type == 'contest' || type == 'action') applyChatButtonPermissions(message, html)
+            const socket = getRollerSocket();
+            if (type == 'contest' || type == 'action') {
+                applyChatButtonPermissions(message, html);
+            }
             else if (type == 'source') {
-                const display = message.getFlag('bizarre-adventures-d6', 'displayId');
-
+                const displayId = message.getFlag('bizarre-adventures-d6', 'displayId');
+                await socket.executeForEveryone("rerenderMessage", message.id); //rerender message expects source message
+                // socket.executeForOthers("updateDisplay", displayId)
                 if (!isDebugEnabled()) html.remove();
+
             }
         });
+
+
 
         $(document).on("click", ".chat-message .select-stat", async (event) => {
             event.preventDefault();
@@ -279,8 +306,9 @@ export async function registerChatListeners() {
                     {
                     const actorSources = getRollableActorSources({ warnOnFail: true, hardStopOnFail: true });
                     if (!actorSources) return;
-                    const luckActors = chooseLuckSpenders(actorSources);
-                    const shouldContinue = await dispatchLuckMove(sourceMessageId, luckActors, quadrantNum, actionArg, false);
+                    const luckActors = chooseLuckSpenders(actorSources); // TODO: Replace with user choice
+                    const shouldContinue = await dispatchLuckMove(sourceMessageId, luckActors, quadrantNum, actionArg, false); // TODO: Luck move must run with context of current user, then switch to GM as necessary
+                    // const shouldContinue = executeLuckMove(sourceMessageId, luckActors, quadrantNum, actionArg, false);
                     if (!shouldContinue) return;
                     }
                     break;
@@ -293,13 +321,16 @@ export async function registerChatListeners() {
                         const newAdvantage = await renderDialog("advantage", { quadrantNum: Number(quadrantNum), currentAdvantage: pairAdvantage });
                         if (newAdvantage === null || newAdvantage === undefined) return; // TODO: confirm changing from break to return solves passing advantage even on fail
                         await dispatchSetPairAdvantage(sourceMessageId, Number(quadrantNum), newAdvantage);
+                        return;
                         break;
                     }
+                    /*
                     if (actionArg === "reckless") {
                         const currentReckless = getPairReckless(message, Number(quadrantNum));
                         await dispatchSetPairReckless(sourceMessageId, Number(quadrantNum), !currentReckless);
                         break;
                     }
+                    */
                     ui.notifications.warn("Unknown action for button: " + button.dataset.action);
                     return;
                 default:

--- a/modules/apps/bad6-roller.js
+++ b/modules/apps/bad6-roller.js
@@ -410,12 +410,14 @@ async function dispatchResetQuadrant(messageId, quadrantNum, refundLuck = true) 
 
 async function dispatchLuckMove(messageId, spenders, quadrantNum, move, isGambit = false) {
     const sender = game.user.id;
+    /*
     if (game.user.isGM) {
         await executeLuckMove(messageId, spenders, quadrantNum, move, isGambit, sender);
         const updatedMessage = game.messages.get(messageId);
         if (updatedMessage) await rerenderMessage(updatedMessage);
         return;
     }
+    */
     return await executeRollerAsGM("rollerExecuteLuckMove", messageId, spenders, quadrantNum, move, isGambit, sender);
 }
 
@@ -428,12 +430,12 @@ async function dispatchSetPairAdvantage(messageId, quadrantNum, advantage) {
     if (game.user.isGM) return await applySetPairAdvantage(messageId, quadrantNum, advantage);
     return await executeRollerAsGM("rollerSetPairAdvantage", messageId, quadrantNum, advantage);
 }
-
+/*
 async function dispatchSetPairReckless(messageId, quadrantNum, reckless) {
     if (game.user.isGM) return await applySetPairReckless(messageId, quadrantNum, reckless);
     return await executeRollerAsGM("rollerSetPairReckless", messageId, quadrantNum, reckless);
 }
-
+*/
 async function applyPairControlMutation(messageId, mutateFn) {
     let message = game.messages.get(messageId);
     if (!message) return;
@@ -570,7 +572,7 @@ export async function resetQuadrant(messageId, quadrantNum, refundLuck = true) {
                 for (const spender in moveSpenders) {
                     const count = moveSpenders[spender] || 0;
                     for (let i = 0; i < count; i++) {
-                        await trySpendLuck(spender, moveData.name, true, true);
+                        await trySpendLuck(spender, moveData.name, true, true); // TODO: Confirm logic survived gambit change
                     }
                 }
             }
@@ -590,12 +592,13 @@ export async function resetQuadrant(messageId, quadrantNum, refundLuck = true) {
 }
 
 async function renderStatSelectionDialog(messageId, quadrantNum, actorSources) {
+    console.log("renderStatSelectionDialog");
     if (!actorSources.length) return;
     const quadrantNumber = Number(quadrantNum);
     const message = game.messages.get(messageId);
     const blockedUniqueLineIds = new Set(getPairUsedUniqueModifierIds(message, quadrantNum)); // Unique line is the same as Per-pair line
     void message; // pair advantage is set independently via the advantage control
-
+    console.log("message voided");
     // Create map of sources
     const actors = actorSources.map(source => {
         // Resolve actor from sourceUuid or actorId
@@ -628,18 +631,19 @@ async function renderStatSelectionDialog(messageId, quadrantNum, actorSources) {
             stats: statsArray
         };
     }).filter(a => a);
-
+    console.log("actors filtered");
     // Create dialog
-    const statDialogResult = await renderDialog('stat', { actors, quadrantNum });
+    const statDialogResult = await renderDialog("stat", { actors, quadrantNum });
+    console.log(statDialogResult);
     if (!statDialogResult) return;
-
+    console.log("yea");
     const { stat, sourceUuid, actorId, selectedModifierIds = [], gambit = null } = statDialogResult;
     if (!stat) return;
     if (!sourceUuid && !actorId) return;
-
+    console.log("yea");
     const actor = resolveActorFromSource({ sourceUuid, actorId });
     if (!actor) return;
-
+    console.log("yea");
     const specialArray = Array.isArray(actor.system.attributes.stats?.[stat]?.special)
         ? actor.system.attributes.stats[stat].special
         : [];
@@ -653,7 +657,7 @@ async function renderStatSelectionDialog(messageId, quadrantNum, actorSources) {
             length: specialArray.length
         });
     }
-
+    console.log("yea");
     if (specialArray.length > 0) {
         const specialWithStat = [stat, ...specialArray];
         const specialStat = await renderDialog("special", { specialArray: specialWithStat });
@@ -673,7 +677,7 @@ async function renderStatSelectionDialog(messageId, quadrantNum, actorSources) {
         console.log(`No specials found for stat "${stat}"`);
         }
     }
-
+    console.log("success!!!!!!!!!!!!!!!!!!!!!!");
     let hasGambit = false;
     if (gambit.luckMove) {
         await message.setFlag("bizarre-adventures-d6", `quadrant${quadrantNum}GambitData`, {
@@ -682,6 +686,8 @@ async function renderStatSelectionDialog(messageId, quadrantNum, actorSources) {
         });
         hasGambit = true;
     }
+    console.log("success!!!!!!!!!!!!!!!!!!!!!!");
+    // console.log(message.getFlag("bizarre-adventures-d6", `quadrant${quadrantNum}GambitData`));
 
     return { stat, sourceUuid, actorId, statValue, selectedSpecial, selectedModifierIds, hasGambit }; //TODO: add hasGambit logic to all who call this function
     
@@ -775,8 +781,11 @@ export async function rollAll(messageId) {
         
         // Create all gambits
         for (let i = 1; i <= (type === "action" ? 2 : 4); i++) {
-            const gambitData = message.getFlag("bizarre-adventures-d6", `quadrant${i}GambitData`);
-            if (gambitData?.gambit) createGambit(gambitData.actorId, gambitData.gambit);
+            const gambitData = {
+                item: message.getFlag("bizarre-adventures-d6", `quadrant${i}GambitData`),
+                state: "create"
+            } 
+            if (gambitData?.item) executeLuckMove(messageId, gambitData.item.actorId, i, "gambit", gambitData); // TODO: Flashback gmabits and others that require senders have improper context
         }
     }
 }

--- a/modules/apps/roller/display.js
+++ b/modules/apps/roller/display.js
@@ -9,6 +9,7 @@ import { resolveActorFromSource } from "./actors.js";
 import { getPairAdvantage, getPairFudgeBonus, getPairReckless } from "./pair-controls.js";
 import { getContestResultLabel } from "./roll-resolution.js";
 import { canViewerSeeQuadrant } from "./chat.js";
+import { getRollerSocket } from "../../sockets.js";
 
 const renderTemplateV1 = foundry.applications.handlebars.renderTemplate;
 
@@ -239,12 +240,15 @@ function logVisibilityDecision(type, { sourceUuid, actorId, actor, quadrant = nu
 // ---------------------------------------------------------------------------
 
 export async function rerenderMessage(message) {
+    if (!message) return;
+
     let type = message.getFlag("bizarre-adventures-d6", "type");
     let targetMessage = message; // What message gets rerendered with the action/contest template
     // if (type != "source") ui.notifications.error("AAAAAAAAAAAAAA");
     const displayId = message.getFlag("bizarre-adventures-d6", "displayId");
     const displayMessage = game.messages.get(displayId);
-    type = displayMessage.getFlag("bizarre-adventures-d6", "type");
+    type = displayMessage?.getFlag("bizarre-adventures-d6", "type");
+    if (!type) return; // action does not start with a type flag, this targets that.
     targetMessage = displayMessage;
 
     const quadrants = {};
@@ -386,16 +390,18 @@ export async function rerenderMessage(message) {
     });
     // Apply to the current message (Update based on template)
     // TODO: All rerenders should also recalculate permissions. This will require having something to calculate those permissions to begin with.
-    if (type == "action") {
-        const pairAdvantage = getPairAdvantage(message, 1) ?? 0;
-        await message.update({ content: await renderSource({ quadrants, isResolved, resolveLabel, resolveTooltip, resolveStateClass, pairAdvantage }) });
-    } else { // its a contest
-        const actionPairAdvantage = getPairAdvantage(message, 1) ?? 0;
-        const reactionPairAdvantage = getPairAdvantage(message, 3) ?? 0;
-        const reactionPairReckless = reactionReckless;
-        await message.update({ content: await renderSource({ quadrants, isResolved, resolveLabel, resolveTooltip, resolveStateClass, actionPairAdvantage, reactionPairAdvantage, reactionPairReckless }) });
+    // All users now run this function, not just GM
+    if (game.user.isGM) {
+        if (type == "action") {
+            const pairAdvantage = getPairAdvantage(message, 1) ?? 0;
+            await message.update({ content: await renderSource({ quadrants, isResolved, resolveLabel, resolveTooltip, resolveStateClass, pairAdvantage }) });
+        } else { // it's a contest
+            const actionPairAdvantage = getPairAdvantage(message, 1) ?? 0;
+            const reactionPairAdvantage = getPairAdvantage(message, 3) ?? 0;
+            const reactionPairReckless = reactionReckless;
+            await message.update({ content: await renderSource({ quadrants, isResolved, resolveLabel, resolveTooltip, resolveStateClass, actionPairAdvantage, reactionPairAdvantage, reactionPairReckless }) });
+        }
     }
-
     if (isDebugEnabled()) {
         const updatedMessage = game.messages.get(targetMessage.id) || targetMessage;
         const messageData = updatedMessage.toObject();
@@ -417,7 +423,7 @@ export async function rerenderMessage(message) {
             fullMessageData: messageData
         });
     }
-    // rerenderDisplayMessage(displayMessage);
+    rerenderDisplayMessage(displayMessage);
 }
 // TODO: Must calculate each quadrant's visiblity based on message flags
 export async function rerenderDisplayMessage(message) {
@@ -593,4 +599,6 @@ export async function rerenderDisplayMessage(message) {
         const reactionPairAdvantage = getPairAdvantage(sourceMessage, 3) ?? 0;
         contentNode.innerHTML = await renderContest({ quadrants, actionPairAdvantage, reactionPairAdvantage, reactionPairReckless: reactionReckless, isResolved, resolveLabel, resolveTooltip, resolveStateClass });
     }
+    // Hopefully forces updates on all clients
+    // if (game.user.isGM) await message.setFlag("bizarre-adventures-d6", "lastUpdate", Date.now());
 }

--- a/modules/dialog.js
+++ b/modules/dialog.js
@@ -1,7 +1,7 @@
 import { actionLabels } from "./constants.js";
 import { getScope } from "./dice.js";
-import { LUCK_MOVES } from "./luck-moves.js";
-import { resolveActorFromSource } from "./apps/roller/actors.js";
+import { chooseLuckSpenders, LUCK_MOVES, trySpendLuck } from "./luck-moves.js";
+import { getRollableActorSources, resolveActorFromSource } from "./apps/roller/actors.js";
 const renderTemplateV1 = foundry.applications.handlebars.renderTemplate;
 
 function capitalizeFirst(text) {
@@ -50,492 +50,525 @@ export function buildGambitDialogEntries(actorEntries = []) {
 
 export async function renderDialog(dialog, dialogData = {}) {
     // Requires actor object
-    if (dialog === "gambit") {
-        const luckMoves = Object.fromEntries(
-                        Object.entries(LUCK_MOVES)
-                    );
-        const gambitsByActor = buildGambitDialogEntries(dialogData.actors).map(({ actor, actorId, sourceUuid }) => ({
-            actor,
-            actorId,
-            sourceUuid
-        }));
-        const content = await renderTemplateV1(
-            "systems/bizarre-adventures-d6/templates/dialog/gambit.hbs",
-            { gambitsByActor, luckMoves, quadrantNum: dialogData.quadrantNum }
-        );
-        return await new Promise((resolve) => {
-            new Dialog({
-                title: `Select a Gambit for ${actionLabels[dialogData.quadrantNum - 1].label} (CANNOT BE UNDONE ONCE REVEALED)`,
-                content,
-                buttons: {
-                    confirm: {
-                        label: "Confirm",
-                        callback: (html) => { 
-
-                            const selectedGambitName = html.find(".gambit-option.selected").data("gambitName") || null;
-                            // const selectedSourceUuid = html.find(".gambit-option.selected").data("sourceUuid");
-                            const selectedGambitedMove =  html.find(".gambit-option.selected").data("gambitMove")
-                            const selectedActorId = html.find(".gambit-option.selected").data("actorId");
-                            const selectedItemId = html.find(".gambit-option.selected").data("itemId");
-
-                            if (!selectedGambitName) {
-                                ui.notifications.warn("Pick a Gambit first.");
-                                return;
-                            }
-
-                            resolve({
-                                gambit: {
-                                    name: selectedGambitName,
-                                    move: selectedGambitedMove,
-                                    actorId: selectedActorId,
-                                    itemId: selectedItemId
-                                },
-                                // sourceUuid: selectedSourceUuid,
-                                itemId: selectedItemId,
-                                actorId: selectedActorId
-                            });
-                        }
-                    },
-                    cancel: {
-                        label: "Cancel",
-                        callback: () => resolve(null)
-                    }
-                },
-                render: (html) => {
-                    const dialogApp = html.closest(".app");
-                    const dialogButtons = dialogApp.find(".dialog-buttons");
-                    const confirmBtn = dialogButtons.find('button[data-button="confirm"]');
-
-                    const isReady = () => html.find(".gambit-option.selected").length > 0;
-
-                    const triggerInvalidConfirmFeedback = () => {
-                        confirmBtn.removeClass("bad6-invalid-shake");
-                        void confirmBtn[0]?.offsetWidth;
-                        confirmBtn.addClass("bad6-invalid-shake");
-                        window.setTimeout(() => confirmBtn.removeClass("bad6-invalid-shake"), 220);
-                    };
-
-                    const updateConfirmState = () => {
-                        const enabled = isReady();
-                        confirmBtn
-                            .prop("disabled", !enabled)
-                            .attr("title", enabled ? "" : "Pick a Gambit first.")
-                            .attr("aria-disabled", !enabled)
-                            .toggleClass("is-disabled", !enabled);
-                    };
-
-                    const onConfirmAttemptCapture = (event) => {
-                        if (isReady()) return;
-                        triggerInvalidConfirmFeedback();
-                        ui.notifications.warn("Pick a Gambit first.");
-                        event.preventDefault();
-                        event.stopPropagation();
-                        event.stopImmediatePropagation();
-                    };
-
-                    confirmBtn[0]?.addEventListener("click", onConfirmAttemptCapture, true);
-
-                    html.find(".gambit-option").on("click", function () {
-                        html.find(".gambit-option").removeClass("selected");
-                        $(this).addClass("selected");
-                        updateConfirmState();
-                    });
-
-                    updateConfirmState();
-                },
-                close: () => resolve(null),
-                default: "confirm"
-            }, { width: 560, height: "auto", resizable: true }).render(true);
-        });
-
-    }
-
-    if (dialog === "stat") {
-        const luckMoves = Object.fromEntries( //TODO: Add logic to fail luck buttons you cannot use. Base this off of highlighted token for gm, and owned actors for player.
-                                Object.entries(LUCK_MOVES).filter(([key]) => key !== "gambit") // Cannot save a gambit with a gambit
-                            );
-        const content = await renderTemplateV1(
-            "systems/bizarre-adventures-d6/templates/dialog/stat.hbs",
-            { actors: dialogData.actors, quadrantNum: dialogData.quadrantNum, currentAdvantage: dialogData.currentAdvantage, luckMoves }
-        );
-
-        return await new Promise((resolve) => {
-            new Dialog({
-                title: `Select Stat and Gambit for ${actionLabels[dialogData.quadrantNum - 1].label}`,
-                content,
-                buttons: {
-                    confirm: {
-                        label: "Confirm",
-                        callback: (html) => { 
-                            const gambitName =  html.find("#gambit-name").val() || null;
-                            const gambitTrigger =  html.find("#gambit-trigger").val()|| null;
-                            const gambitMove = html.find(".gambit-option.selected").data("stat")|| null;
-
-                            const selectedStat = html.find(".stat-option.selected").data("stat");
-                            const selectedSourceUuid = html.find(".stat-option.selected").data("sourceUuid");
-                            const selectedActorId = html.find(".stat-option.selected").data("actorId");
-                            const selectedModifierIds = html.find(".custom-modifier-option:checked")
-                                .map((_, el) => String(el.value))
-                                .get();
-
-                            if (!selectedStat) {
-                                ui.notifications.warn("Pick a Stat first.");
-                                return;
-                            }
-                            
-                            if (gambitMove || gambitTrigger || gambitName) {
-                                if (!gambitMove) {
-                                    ui.notifications.warn("Incomplete Gambit: Gambit requires a luck move.");
-                                    return;
-                                }
-                                if (!gambitTrigger) {
-                                    ui.notifications.warn("Incomplete Gambit: Gambit requires a trigger.");
-                                    return;
-                                }
-                                if (!gambitName) {
-                                    ui.notifications.warn("Incomplete Gambit: Gambit requires a name.");
-                                    return;
-                                }
-                            }
-
-                            resolve({
-                                stat: selectedStat,
-                                sourceUuid: selectedSourceUuid,
-                                actorId: selectedActorId,
-                                selectedModifierIds,
-                                gambit: {
-                                    name: gambitName,
-                                    trigger: gambitTrigger,
-                                    luckMove: gambitMove
-                                }
-                            });
-                        }
-                    },
-                    cancel: {
-                        label: "Cancel",
-                        callback: () => resolve(null)
-                    }
-                },
-                render: (html) => {
-                    const dialogApp = html.closest(".app");
-                    const dialogButtons = dialogApp.find(".dialog-buttons");
-                    const confirmBtn = dialogButtons.find('button[data-button="confirm"]');
-
-                    const isReady = () => html.find(".stat-option.selected").length > 0;
-
-                    const triggerInvalidConfirmFeedback = () => {
-                        confirmBtn.removeClass("bad6-invalid-shake");
-                        void confirmBtn[0]?.offsetWidth;
-                        confirmBtn.addClass("bad6-invalid-shake");
-                        window.setTimeout(() => confirmBtn.removeClass("bad6-invalid-shake"), 220);
-                    };
-
-                    const updateConfirmState = () => {
-                        const enabled = isReady();
-                        confirmBtn
-                            .prop("disabled", !enabled)
-                            .attr("title", enabled ? "" : "Pick a Stat first.")
-                            .attr("aria-disabled", !enabled)
-                            .toggleClass("is-disabled", !enabled);
-                    };
-
-                    const onConfirmAttemptCapture = (event) => {
-                        if (isReady()) return;
-                        triggerInvalidConfirmFeedback();
-                        ui.notifications.warn("Pick a Stat first.");
-                        event.preventDefault();
-                        event.stopPropagation();
-                        event.stopImmediatePropagation();
-                    };
-
-                    confirmBtn[0]?.addEventListener("click", onConfirmAttemptCapture, true);
-
-                    const parseSelectedModifiers = () => {
-                        const selectedButton = html.find(".stat-option.selected");
-                        if (!selectedButton.length) return [];
-                        const encoded = selectedButton.attr("data-modifiers") || "";
-                        if (!encoded) return [];
-                        try {
-                            const parsed = JSON.parse(decodeURIComponent(encoded));
-                            return Array.isArray(parsed) ? parsed : [];
-                        } catch (_error) {
-                            return [];
-                        }
-                    };
-
-                    const formatModifierLabel = (line) => {
-                        const variable = capitalizeFirst(line.variable || "modifier");
-                        const sourceName = line.sourceName || "Custom";
-                        const lineValue = Number(line.value ?? 0);
-                        const perPairBadge = line.unique
-                            ? (line.unavailable ? " [Per-pair: used]" : " [Per-pair]")
-                            : "";
-                        return `${variable} ${line.operand || "+"} ${lineValue} (${sourceName})${perPairBadge}`;
-                    };
-
-                    const renderCustomModifierChoices = () => {
-                        const container = html.find(".custom-modifier-list");
-                        if (!container.length) return;
-
-                        const selectedButton = html.find(".stat-option.selected");
-                        if (!selectedButton.length) {
-                            container.html("<em>Select a stat to view custom modifiers.</em>");
-                            return;
-                        }
-
-                        const existingChecked = new Set(
-                            container.find(".custom-modifier-option:checked").map((_, el) => String(el.value)).get()
+    switch (dialog) {
+        case "gambit": {
+            const luckMoves = Object.fromEntries(
+                            Object.entries(LUCK_MOVES)
                         );
+            const gambitsByActor = buildGambitDialogEntries(dialogData.actors).map(({ actor, actorId, sourceUuid }) => ({
+                actor,
+                actorId,
+                sourceUuid
+            }));
+            const content = await renderTemplateV1(
+                "systems/bizarre-adventures-d6/templates/dialog/gambit.hbs",
+                { gambitsByActor, luckMoves, quadrantNum: dialogData.quadrantNum }
+            );
+            return await new Promise((resolve) => {
+                new Dialog({
+                    title: `Select a Gambit for ${actionLabels[dialogData.quadrantNum - 1].label} (CANNOT BE UNDONE ONCE REVEALED)`,
+                    content,
+                    buttons: {
+                        confirm: {
+                            label: "Confirm",
+                            callback: (html) => { 
 
-                        const selectedStat = String(selectedButton.data("stat") || "").trim().toLowerCase();
-                        const allLines = parseSelectedModifiers();
-                        const scope = getScope(selectedStat);
-                        const filtered = allLines.filter((line) => {
-                            const lineStat = String(line?.stat || "").trim().toLowerCase();
-                            return !lineStat || lineStat === selectedStat || lineStat === scope;
+                                const selectedGambitName = html.find(".gambit-option.selected").data("gambitName") || null;
+                                // const selectedSourceUuid = html.find(".gambit-option.selected").data("sourceUuid");
+                                const selectedGambitedMove =  html.find(".gambit-option.selected").data("gambitMove")
+                                const selectedActorId = html.find(".gambit-option.selected").data("actorId");
+                                const selectedItemId = html.find(".gambit-option.selected").data("itemId");
+
+                                if (!selectedGambitName) {
+                                    ui.notifications.warn("Pick a Gambit first.");
+                                    return;
+                                }
+
+                                resolve({
+                                    gambit: {
+                                        name: selectedGambitName,
+                                        move: selectedGambitedMove,
+                                        actorId: selectedActorId,
+                                        itemId: selectedItemId
+                                    },
+                                    // sourceUuid: selectedSourceUuid,
+                                    itemId: selectedItemId,
+                                    actorId: selectedActorId
+                                });
+                            }
+                        },
+                        cancel: {
+                            label: "Cancel",
+                            callback: () => resolve(null)
+                        }
+                    },
+                    render: (html) => {
+                        const dialogApp = html.closest(".app");
+                        const dialogButtons = dialogApp.find(".dialog-buttons");
+                        const confirmBtn = dialogButtons.find('button[data-button="confirm"]');
+
+                        const isReady = () => html.find(".gambit-option.selected").length > 0;
+
+                        const triggerInvalidConfirmFeedback = () => {
+                            confirmBtn.removeClass("bad6-invalid-shake");
+                            void confirmBtn[0]?.offsetWidth;
+                            confirmBtn.addClass("bad6-invalid-shake");
+                            window.setTimeout(() => confirmBtn.removeClass("bad6-invalid-shake"), 220);
+                        };
+
+                        const updateConfirmState = () => {
+                            const enabled = isReady();
+                            confirmBtn
+                                .prop("disabled", !enabled)
+                                .attr("title", enabled ? "" : "Pick a Gambit first.")
+                                .attr("aria-disabled", !enabled)
+                                .toggleClass("is-disabled", !enabled);
+                        };
+
+                        const onConfirmAttemptCapture = (event) => {
+                            if (isReady()) return;
+                            triggerInvalidConfirmFeedback();
+                            ui.notifications.warn("Pick a Gambit first.");
+                            event.preventDefault();
+                            event.stopPropagation();
+                            event.stopImmediatePropagation();
+                        };
+
+                        confirmBtn[0]?.addEventListener("click", onConfirmAttemptCapture, true);
+
+                        html.find(".gambit-option").on("click", function () {
+                            html.find(".gambit-option").removeClass("selected");
+                            $(this).addClass("selected");
+                            updateConfirmState();
                         });
 
-                        const required = filtered.filter((line) => !line.optional);
-                        const optional = filtered.filter((line) => !!line.optional);
-                        
-                        if (!required.length && !optional.length) {
-                            container.html("<em>No custom modifiers for this stat.</em>");
-                            return;
-                        }
-
-                        const chunks = [];
-                        if (required.length) {
-                            chunks.push('<div class="custom-modifier-group"><strong>Auto-applied</strong></div>');
-                            for (const line of required) {
-                                const unavailableClass = line.unavailable ? " is-unavailable" : "";
-                                const reason = line.unavailable && line.unavailableReason ? ` — ${line.unavailableReason}` : "";
-                                chunks.push(`<div class="custom-modifier-auto${unavailableClass}">• ${formatModifierLabel(line)}${reason}</div>`);
-                            }
-                        }
-
-                        if (optional.length) {
-                            chunks.push('<div class="custom-modifier-group"><strong>Optional</strong></div>');
-                            for (const line of optional) {
-                                const lineId = String(line.id || "");
-                                const isUnavailable = !!line.unavailable;
-                                const checked = !isUnavailable && existingChecked.has(lineId) ? "checked" : "";
-                                const disabled = isUnavailable ? "disabled" : "";
-                                const unavailableClass = isUnavailable ? " is-unavailable" : "";
-                                const reason = isUnavailable && line.unavailableReason ? ` — ${line.unavailableReason}` : "";
-                                chunks.push(
-                                    `<label class="custom-modifier-option-row${unavailableClass}">` +
-                                    `<input class="custom-modifier-option" type="checkbox" value="${lineId}" ${checked} ${disabled} /> ` +
-                                    `${formatModifierLabel(line)}${reason}` +
-                                    `</label>`
-                                );
-                            }
-                        }
-
-                        container.html(chunks.join(""));
-                    };
-
-                    html.find(".stat-option").on("click", function () {
-                        html.find(".stat-option").removeClass("selected");
-                        $(this).addClass("selected");
-                        renderCustomModifierChoices();
                         updateConfirmState();
-                    });
+                    },
+                    close: () => resolve(null),
+                    default: "confirm"
+                }, { width: 560, height: "auto", resizable: true }).render(true);
+            });
 
-                    html.find(".gambit-option").on("click", function () {
-                        html.find(".gambit-option").removeClass("selected");
-                        $(this).addClass("selected");
-                    });
+        }
+    
+        case "stat": {
+            const luckMoves = Object.fromEntries( //TODO: Add logic to fail luck buttons you cannot use. Base this off of highlighted token for gm, and owned actors for player.
+                                    Object.entries(LUCK_MOVES).filter(([key]) => key !== "gambit") // Cannot save a gambit with a gambit
+                                );
+            const content = await renderTemplateV1(
+                "systems/bizarre-adventures-d6/templates/dialog/stat.hbs",
+                { actors: dialogData.actors, quadrantNum: dialogData.quadrantNum, currentAdvantage: dialogData.currentAdvantage, luckMoves }
+            );
 
-                    renderCustomModifierChoices();
-                    updateConfirmState();
-                },
-                close: () => resolve(null),
-                default: "confirm"
-            }, { width: 560, height: "auto", resizable: true }).render(true);
-        });
-    }
+            return await new Promise((resolve) => {
+                new Dialog({
+                    title: `Select Stat and Gambit for ${actionLabels[dialogData.quadrantNum - 1].label}`,
+                    content,
+                    buttons: {
+                        confirm: {
+                            label: "Confirm",
+                            callback: async (html) => { 
+                                const gambitName =  html.find("#gambit-name").val() || null;
+                                const gambitTrigger =  html.find("#gambit-trigger").val()|| null;
+                                const gambitMove = html.find(".gambit-option.selected").data("stat")|| null;
 
-    if (dialog === "advantage") {
-        const content = await renderTemplateV1(
-            "systems/bizarre-adventures-d6/templates/dialog/advantage.hbs",
-            { currentAdvantage: dialogData.currentAdvantage }
-        );
+                                const selectedStat = html.find(".stat-option.selected").data("stat");
+                                const selectedSourceUuid = html.find(".stat-option.selected").data("sourceUuid");
+                                const selectedActorId = html.find(".stat-option.selected").data("actorId");
+                                const selectedModifierIds = html.find(".custom-modifier-option:checked")
+                                    .map((_, el) => String(el.value))
+                                    .get();
 
-        const rawQuadrant = Number(dialogData.quadrantNum);
-        const pairedEvenQuadrant = Number.isInteger(rawQuadrant)
-            ? (rawQuadrant % 2 === 0 ? rawQuadrant : rawQuadrant + 1)
-            : null;
-        const pairLabel = actionLabels[(pairedEvenQuadrant ?? 0) - 1]?.label ?? "Pair";
+                                if (!selectedStat) {
+                                    ui.notifications.warn("Pick a Stat first.");
+                                    return;
+                                }
+                                
+                                if (gambitMove || gambitTrigger || gambitName) {
+                                    if (!gambitMove) {
+                                        ui.notifications.warn("Incomplete Gambit: Gambit requires a luck move.");
+                                        return;
+                                    }
+                                    if (!gambitTrigger) {
+                                        ui.notifications.warn("Incomplete Gambit: Gambit requires a trigger.");
+                                        return;
+                                    }
+                                    if (!gambitName) {
+                                        ui.notifications.warn("Incomplete Gambit: Gambit requires a name.");
+                                        return;
+                                    }
+                                    // TODO: Move luck spending to luckmoves.js
+                                    const actorSources = getRollableActorSources({ warnOnFail: true, hardStopOnFail: true });
+                                    const spenders = chooseLuckSpenders(actorSources); // 0 = temp, 1 = perm, 2 = value
+                                    const burnType = LUCK_MOVES[gambitMove].costType;
+                                    let spenderId = null;
+                                    switch (burnType) {
+                                        case "temp": {
+                                            spenderId = spenders[0];
+                                            break;
+                                        }
+                                        case "perm": {
+                                            spenderId = spenders[1];
+                                            break;
+                                        }
+                                        case "value": {
+                                            spenderId = spenders[2];
+                                            break;
+                                        }
+                                        default:
+                                            ui.notifications.error(`Unknown luck cost type: ${burnType}`);
+                                            return;
+                                            
+                                    }
+                                    const gambitSuccess = await trySpendLuck(spenderId, gambitMove);
+                                    console.log(gambitSuccess);
+                                    if (!gambitSuccess) {
+                                        ui.notifications.error(`Not enough ${burnType} luck`);
+                                        return;
+                                    }
+                                }
 
-        return await new Promise((resolve) => {
-            let settled = false;
-            const settle = (value) => {
-                if (settled) return;
-                settled = true;
-                resolve(value);
-            };
+                                resolve({
+                                    stat: selectedStat,
+                                    sourceUuid: selectedSourceUuid,
+                                    actorId: selectedActorId,
+                                    selectedModifierIds,
+                                    gambit: {
+                                        name: gambitName,
+                                        trigger: gambitTrigger,
+                                        luckMove: gambitMove
+                                    }
+                                });
+                            }
+                        },
+                        cancel: {
+                            label: "Cancel",
+                            callback: () => resolve(null)
+                        }
+                    },
+                    render: (html) => {
+                        const dialogApp = html.closest(".app");
+                        const dialogButtons = dialogApp.find(".dialog-buttons");
+                        const confirmBtn = dialogButtons.find('button[data-button="confirm"]');
 
-            const dialogApp = new Dialog({
-                title: `Select Advantage for ${pairLabel}`,
-                content,
-                buttons: {
-                    cancel: {
-                        label: "Cancel",
-                        callback: () => settle(null)
-                    }
-                },
-                render: (html) => {
-                    const currentAdvantage = Number(dialogData.currentAdvantage);
-                    if (Number.isInteger(currentAdvantage) && currentAdvantage >= 0 && currentAdvantage <= 3) {
-                        html.find(`.advantage-option[data-advantage="${currentAdvantage}"]`).addClass("is-current");
-                    }
+                        const isReady = () => html.find(".stat-option.selected").length > 0;
 
-                    html.find(".advantage-option").on("click", (event) => {
-                        const selected = Number($(event.currentTarget).data("advantage"));
-                        const safeAdvantage = Number.isFinite(selected)
-                            ? Math.max(0, Math.min(3, Math.floor(selected)))
-                            : 0;
+                        const triggerInvalidConfirmFeedback = () => {
+                            confirmBtn.removeClass("bad6-invalid-shake");
+                            void confirmBtn[0]?.offsetWidth;
+                            confirmBtn.addClass("bad6-invalid-shake");
+                            window.setTimeout(() => confirmBtn.removeClass("bad6-invalid-shake"), 220);
+                        };
 
-                        settle(safeAdvantage);
-                        dialogApp.close();
-                    });
-                },
-                close: () => settle(null),
-                default: "cancel"
-            }, { width: 360, height: "auto", resizable: false });
+                        const updateConfirmState = () => {
+                            const enabled = isReady();
+                            confirmBtn
+                                .prop("disabled", !enabled)
+                                .attr("title", enabled ? "" : "Pick a Stat first.")
+                                .attr("aria-disabled", !enabled)
+                                .toggleClass("is-disabled", !enabled);
+                        };
 
-            dialogApp.render(true);
-        });
-    }
+                        const onConfirmAttemptCapture = (event) => {
+                            if (isReady()) return;
+                            triggerInvalidConfirmFeedback();
+                            ui.notifications.warn("Pick a Stat first.");
+                            event.preventDefault();
+                            event.stopPropagation();
+                            event.stopImmediatePropagation();
+                        };
 
-    if (dialog === "special") {
-        const specialArray = dialogData.specialArray;
-        const baseStat = specialArray[0];
-        const baseStatKey = typeof baseStat === "string" ? baseStat : baseStat.key;
-        const baseStatLabel = capitalizeFirst(typeof baseStat === "string" ? baseStat : baseStat.label);
-        const baseStatValue = typeof baseStat === "string" ? null : baseStat.value;
+                        confirmBtn[0]?.addEventListener("click", onConfirmAttemptCapture, true);
 
-        const specials = specialArray.slice(1).map((special, index) => {
-            const fallbackKey = (`special-${index}`).toString().trim();
-            const specialLabel = capitalizeFirst(special?.label ?? special?.key ?? fallbackKey).toString();
-            return {
-                key: (special?.key ?? fallbackKey).toString(),
-                label: `${baseStatLabel} (${specialLabel})`,
-                value: Number(special?.value ?? 0)
-            };
-        });
+                        const parseSelectedModifiers = () => {
+                            const selectedButton = html.find(".stat-option.selected");
+                            if (!selectedButton.length) return [];
+                            const encoded = selectedButton.attr("data-modifiers") || "";
+                            if (!encoded) return [];
+                            try {
+                                const parsed = JSON.parse(decodeURIComponent(encoded));
+                                return Array.isArray(parsed) ? parsed : [];
+                            } catch (_error) {
+                                return [];
+                            }
+                        };
 
-        const stats = [{ key: baseStatKey, label: baseStatLabel, value: baseStatValue }, ...specials];
+                        const formatModifierLabel = (line) => {
+                            const variable = capitalizeFirst(line.variable || "modifier");
+                            const sourceName = line.sourceName || "Custom";
+                            const lineValue = Number(line.value ?? 0);
+                            const perPairBadge = line.unique
+                                ? (line.unavailable ? " [Per-pair: used]" : " [Per-pair]")
+                                : "";
+                            return `${variable} ${line.operand || "+"} ${lineValue} (${sourceName})${perPairBadge}`;
+                        };
 
-        const content = await renderTemplateV1(
-            "systems/bizarre-adventures-d6/templates/dialog/special.hbs",
-            { key: baseStatKey, label: baseStatLabel, stats }
-        );
+                        const renderCustomModifierChoices = () => {
+                            const container = html.find(".custom-modifier-list");
+                            if (!container.length) return;
 
-        return await new Promise((resolve) => {
-            new Dialog({
-                title: "Select a Special",
-                content,
-                buttons: {
-                    confirm: {
-                        label: "Confirm",
-                        callback: (html) => {
-                            const selectedSpecial = html.find(".special-option.selected").data("stat");
-                            if (!selectedSpecial) {
-                                ui.notifications.warn("Pick a Special first.");
+                            const selectedButton = html.find(".stat-option.selected");
+                            if (!selectedButton.length) {
+                                container.html("<em>Select a stat to view custom modifiers.</em>");
                                 return;
                             }
-                            resolve(selectedSpecial);
-                        }
-                    },
-                    cancel: {
-                        label: "Cancel",
-                        callback: () => resolve(null)
-                    }
-                },
-                render: (html) => {
-                    const dialogApp = html.closest(".app");
-                    const dialogButtons = dialogApp.find(".dialog-buttons");
-                    const confirmBtn = dialogButtons.find('button[data-button="confirm"]');
 
-                    const isReady = () => html.find(".special-option.selected").length > 0;
+                            const existingChecked = new Set(
+                                container.find(".custom-modifier-option:checked").map((_, el) => String(el.value)).get()
+                            );
 
-                    const triggerInvalidConfirmFeedback = () => {
-                        confirmBtn.removeClass("bad6-invalid-shake");
-                        void confirmBtn[0]?.offsetWidth;
-                        confirmBtn.addClass("bad6-invalid-shake");
-                        window.setTimeout(() => confirmBtn.removeClass("bad6-invalid-shake"), 220);
-                    };
+                            const selectedStat = String(selectedButton.data("stat") || "").trim().toLowerCase();
+                            const allLines = parseSelectedModifiers();
+                            const scope = getScope(selectedStat);
+                            const filtered = allLines.filter((line) => {
+                                const lineStat = String(line?.stat || "").trim().toLowerCase();
+                                return !lineStat || lineStat === selectedStat || lineStat === scope;
+                            });
 
-                    const updateConfirmState = () => {
-                        const enabled = isReady();
-                        confirmBtn
-                            .prop("disabled", !enabled)
-                            .attr("title", enabled ? "" : "Pick a Stat first.")
-                            .attr("aria-disabled", !enabled)
-                            .toggleClass("is-disabled", !enabled);
-                    };
+                            const required = filtered.filter((line) => !line.optional);
+                            const optional = filtered.filter((line) => !!line.optional);
+                            
+                            if (!required.length && !optional.length) {
+                                container.html("<em>No custom modifiers for this stat.</em>");
+                                return;
+                            }
 
-                    const onConfirmAttemptCapture = (event) => {
-                        if (isReady()) return;
-                        triggerInvalidConfirmFeedback();
-                        ui.notifications.warn("Pick a Stat first.");
-                        event.preventDefault();
-                        event.stopPropagation();
-                        event.stopImmediatePropagation();
-                    };
+                            const chunks = [];
+                            if (required.length) {
+                                chunks.push('<div class="custom-modifier-group"><strong>Auto-applied</strong></div>');
+                                for (const line of required) {
+                                    const unavailableClass = line.unavailable ? " is-unavailable" : "";
+                                    const reason = line.unavailable && line.unavailableReason ? ` — ${line.unavailableReason}` : "";
+                                    chunks.push(`<div class="custom-modifier-auto${unavailableClass}">• ${formatModifierLabel(line)}${reason}</div>`);
+                                }
+                            }
 
-                    confirmBtn[0]?.addEventListener("click", onConfirmAttemptCapture, true);
+                            if (optional.length) {
+                                chunks.push('<div class="custom-modifier-group"><strong>Optional</strong></div>');
+                                for (const line of optional) {
+                                    const lineId = String(line.id || "");
+                                    const isUnavailable = !!line.unavailable;
+                                    const checked = !isUnavailable && existingChecked.has(lineId) ? "checked" : "";
+                                    const disabled = isUnavailable ? "disabled" : "";
+                                    const unavailableClass = isUnavailable ? " is-unavailable" : "";
+                                    const reason = isUnavailable && line.unavailableReason ? ` — ${line.unavailableReason}` : "";
+                                    chunks.push(
+                                        `<label class="custom-modifier-option-row${unavailableClass}">` +
+                                        `<input class="custom-modifier-option" type="checkbox" value="${lineId}" ${checked} ${disabled} /> ` +
+                                        `${formatModifierLabel(line)}${reason}` +
+                                        `</label>`
+                                    );
+                                }
+                            }
 
-                    html.find(".special-option").on("click", function () {
-                        html.find(".special-option").removeClass("selected");
-                        $(this).addClass("selected");
+                            container.html(chunks.join(""));
+                        };
+
+                        html.find(".stat-option").on("click", function () {
+                            html.find(".stat-option").removeClass("selected");
+                            $(this).addClass("selected");
+                            renderCustomModifierChoices();
+                            updateConfirmState();
+                        });
+
+                        html.find(".gambit-option").on("click", function () {
+                            html.find(".gambit-option").removeClass("selected");
+                            $(this).addClass("selected");
+                        });
+
+                        renderCustomModifierChoices();
                         updateConfirmState();
-                    });
+                    },
+                    close: () => resolve(null),
+                    default: "confirm"
+                }, { width: 560, height: "auto", resizable: true }).render(true);
+            });
+        }
 
-                    updateConfirmState();
-                },
-                close: () => resolve(null),
-                default: "confirm"
-            }).render(true);
-        });
-    }
+        case "advantage": {
+            const content = await renderTemplateV1(
+                "systems/bizarre-adventures-d6/templates/dialog/advantage.hbs",
+                { currentAdvantage: dialogData.currentAdvantage }
+            );
 
-    if (dialog === "burn") {
-        const initialValue = String(dialogData.value ?? "");
-        const inputName = "burn-value";
-        const content = `
-            <div class="form-group">
-                <label for="${inputName}">Value</label>
-                <input id="${inputName}" name="${inputName}" type="number" value="${initialValue}" placeholder="Enter value" />
-            </div>
-        `;
+            const rawQuadrant = Number(dialogData.quadrantNum);
+            const pairedEvenQuadrant = Number.isInteger(rawQuadrant)
+                ? (rawQuadrant % 2 === 0 ? rawQuadrant : rawQuadrant + 1)
+                : null;
+            const pairLabel = actionLabels[(pairedEvenQuadrant ?? 0) - 1]?.label ?? "Pair";
 
-        return await new Promise((resolve) => {
-            new Dialog({
-                title: `Change ${dialogData.type} Value`,
-                content,
-                buttons: {
-                    confirm: {
-                        label: "Confirm",
-                        callback: (html) => {
-                            const value = html.find(`input[name="${inputName}"]`).val()?.trim() ?? "";
-                            resolve(value);
+            return await new Promise((resolve) => {
+                let settled = false;
+                const settle = (value) => {
+                    if (settled) return;
+                    settled = true;
+                    resolve(value);
+                };
+
+                const dialogApp = new Dialog({
+                    title: `Select Advantage for ${pairLabel}`,
+                    content,
+                    buttons: {
+                        cancel: {
+                            label: "Cancel",
+                            callback: () => settle(null)
                         }
                     },
-                    cancel: {
-                        label: "Cancel",
-                        callback: () => resolve(null)
-                    }
-                },
-                render: (html) => {
-                    html.find(`input[name="${inputName}"]`).focus();
-                },
-                close: () => resolve(null),
-                default: "confirm"
-            }).render(true);
-        });
-    }
+                    render: (html) => {
+                        const currentAdvantage = Number(dialogData.currentAdvantage);
+                        if (Number.isInteger(currentAdvantage) && currentAdvantage >= 0 && currentAdvantage <= 3) {
+                            html.find(`.advantage-option[data-advantage="${currentAdvantage}"]`).addClass("is-current");
+                        }
 
-    return null;
+                        html.find(".advantage-option").on("click", (event) => {
+                            const selected = Number($(event.currentTarget).data("advantage"));
+                            const safeAdvantage = Number.isFinite(selected)
+                                ? Math.max(0, Math.min(3, Math.floor(selected)))
+                                : 0;
+
+                            settle(safeAdvantage);
+                            dialogApp.close();
+                        });
+                    },
+                    close: () => settle(null),
+                    default: "cancel"
+                }, { width: 360, height: "auto", resizable: false });
+
+                dialogApp.render(true);
+            });
+        }
+
+        if (dialog === "special") {
+            const specialArray = dialogData.specialArray;
+            const baseStat = specialArray[0];
+            const baseStatKey = typeof baseStat === "string" ? baseStat : baseStat.key;
+            const baseStatLabel = capitalizeFirst(typeof baseStat === "string" ? baseStat : baseStat.label);
+            const baseStatValue = typeof baseStat === "string" ? null : baseStat.value;
+
+            const specials = specialArray.slice(1).map((special, index) => {
+                const fallbackKey = (`special-${index}`).toString().trim();
+                const specialLabel = capitalizeFirst(special?.label ?? special?.key ?? fallbackKey).toString();
+                return {
+                    key: (special?.key ?? fallbackKey).toString(),
+                    label: `${baseStatLabel} (${specialLabel})`,
+                    value: Number(special?.value ?? 0)
+                };
+            });
+
+            const stats = [{ key: baseStatKey, label: baseStatLabel, value: baseStatValue }, ...specials];
+
+            const content = await renderTemplateV1(
+                "systems/bizarre-adventures-d6/templates/dialog/special.hbs",
+                { key: baseStatKey, label: baseStatLabel, stats }
+            );
+
+            return await new Promise((resolve) => {
+                new Dialog({
+                    title: "Select a Special",
+                    content,
+                    buttons: {
+                        confirm: {
+                            label: "Confirm",
+                            callback: (html) => {
+                                const selectedSpecial = html.find(".special-option.selected").data("stat");
+                                if (!selectedSpecial) {
+                                    ui.notifications.warn("Pick a Special first.");
+                                    return;
+                                }
+                                resolve(selectedSpecial);
+                            }
+                        },
+                        cancel: {
+                            label: "Cancel",
+                            callback: () => resolve(null)
+                        }
+                    },
+                    render: (html) => {
+                        const dialogApp = html.closest(".app");
+                        const dialogButtons = dialogApp.find(".dialog-buttons");
+                        const confirmBtn = dialogButtons.find('button[data-button="confirm"]');
+
+                        const isReady = () => html.find(".special-option.selected").length > 0;
+
+                        const triggerInvalidConfirmFeedback = () => {
+                            confirmBtn.removeClass("bad6-invalid-shake");
+                            void confirmBtn[0]?.offsetWidth;
+                            confirmBtn.addClass("bad6-invalid-shake");
+                            window.setTimeout(() => confirmBtn.removeClass("bad6-invalid-shake"), 220);
+                        };
+
+                        const updateConfirmState = () => {
+                            const enabled = isReady();
+                            confirmBtn
+                                .prop("disabled", !enabled)
+                                .attr("title", enabled ? "" : "Pick a Stat first.")
+                                .attr("aria-disabled", !enabled)
+                                .toggleClass("is-disabled", !enabled);
+                        };
+
+                        const onConfirmAttemptCapture = (event) => {
+                            if (isReady()) return;
+                            triggerInvalidConfirmFeedback();
+                            ui.notifications.warn("Pick a Stat first.");
+                            event.preventDefault();
+                            event.stopPropagation();
+                            event.stopImmediatePropagation();
+                        };
+
+                        confirmBtn[0]?.addEventListener("click", onConfirmAttemptCapture, true);
+
+                        html.find(".special-option").on("click", function () {
+                            html.find(".special-option").removeClass("selected");
+                            $(this).addClass("selected");
+                            updateConfirmState();
+                        });
+
+                        updateConfirmState();
+                    },
+                    close: () => resolve(null),
+                    default: "confirm"
+                }).render(true);
+            });
+        }
+
+        case "burn": {
+            const initialValue = String(dialogData.value ?? "");
+            const inputName = "burn-value";
+            const content = `
+                <div class="form-group">
+                    <label for="${inputName}">Value</label>
+                    <input id="${inputName}" name="${inputName}" type="number" value="${initialValue}" placeholder="Enter value" />
+                </div>
+            `;
+
+            return await new Promise((resolve) => {
+                new Dialog({
+                    title: `Change ${dialogData.type} Value`,
+                    content,
+                    buttons: {
+                        confirm: {
+                            label: "Confirm",
+                            callback: (html) => {
+                                const value = html.find(`input[name="${inputName}"]`).val()?.trim() ?? "";
+                                resolve(value);
+                            }
+                        },
+                        cancel: {
+                            label: "Cancel",
+                            callback: () => resolve(null)
+                        }
+                    },
+                    render: (html) => {
+                        html.find(`input[name="${inputName}"]`).focus();
+                    },
+                    close: () => resolve(null),
+                    default: "confirm"
+                }).render(true);
+            });
+        }
+        default:
+            console.log("renderDialog call failed, returning null.");
+            return null;
+    }
+    
 }

--- a/modules/dialog.js
+++ b/modules/dialog.js
@@ -1,6 +1,6 @@
 import { actionLabels } from "./constants.js";
 import { getScope } from "./dice.js";
-import { chooseLuckSpenders, LUCK_MOVES, trySpendLuck } from "./luck-moves.js";
+import { chooseLuckSpenders, LUCK_MOVES, trySpendLuck, canUseMove } from "./luck-moves.js";
 import { getRollableActorSources, resolveActorFromSource } from "./apps/roller/actors.js";
 const renderTemplateV1 = foundry.applications.handlebars.renderTemplate;
 
@@ -137,8 +137,9 @@ export async function renderDialog(dialog, dialogData = {}) {
                         confirmBtn[0]?.addEventListener("click", onConfirmAttemptCapture, true);
 
                         html.find(".gambit-option").on("click", function () {
+                            const alreadySelected = $(this).hasClass("selected");
                             html.find(".gambit-option").removeClass("selected");
-                            $(this).addClass("selected");
+                            if (!alreadySelected) $(this).addClass("selected");
                             updateConfirmState();
                         });
 
@@ -161,16 +162,19 @@ export async function renderDialog(dialog, dialogData = {}) {
             );
 
             return await new Promise((resolve) => {
+                let selectedGambitMove = null;
+                let selectedGambitSpenderId = null;
+
                 new Dialog({
                     title: `Select Stat and Gambit for ${actionLabels[dialogData.quadrantNum - 1].label}`,
                     content,
                     buttons: {
                         confirm: {
                             label: "Confirm",
-                            callback: async (html) => { 
-                                const gambitName =  html.find("#gambit-name").val() || null;
-                                const gambitTrigger =  html.find("#gambit-trigger").val()|| null;
-                                const gambitMove = html.find(".gambit-option.selected").data("stat")|| null;
+                            callback: (html) => {
+                                const gambitName = html.find("#gambit-name").val() || null;
+                                const gambitTrigger = html.find("#gambit-trigger").val() || null;
+                                const gambitMove = html.find(".gambit-option.selected").data("stat") || null;
 
                                 const selectedStat = html.find(".stat-option.selected").data("stat");
                                 const selectedSourceUuid = html.find(".stat-option.selected").data("sourceUuid");
@@ -183,7 +187,7 @@ export async function renderDialog(dialog, dialogData = {}) {
                                     ui.notifications.warn("Pick a Stat first.");
                                     return;
                                 }
-                                
+
                                 if (gambitMove || gambitTrigger || gambitName) {
                                     if (!gambitMove) {
                                         ui.notifications.warn("Incomplete Gambit: Gambit requires a luck move.");
@@ -197,35 +201,13 @@ export async function renderDialog(dialog, dialogData = {}) {
                                         ui.notifications.warn("Incomplete Gambit: Gambit requires a name.");
                                         return;
                                     }
-                                    // TODO: Move luck spending to luckmoves.js
-                                    const actorSources = getRollableActorSources({ warnOnFail: true, hardStopOnFail: true });
-                                    const spenders = chooseLuckSpenders(actorSources); // 0 = temp, 1 = perm, 2 = value
-                                    const burnType = LUCK_MOVES[gambitMove].costType;
-                                    let spenderId = null;
-                                    switch (burnType) {
-                                        case "temp": {
-                                            spenderId = spenders[0];
-                                            break;
-                                        }
-                                        case "perm": {
-                                            spenderId = spenders[1];
-                                            break;
-                                        }
-                                        case "value": {
-                                            spenderId = spenders[2];
-                                            break;
-                                        }
-                                        default:
-                                            ui.notifications.error(`Unknown luck cost type: ${burnType}`);
-                                            return;
-                                            
-                                    }
-                                    const gambitSuccess = await trySpendLuck(spenderId, gambitMove);
-                                    console.log(gambitSuccess);
-                                    if (!gambitSuccess) {
-                                        ui.notifications.error(`Not enough ${burnType} luck`);
+                                    if (selectedGambitMove !== gambitMove || !selectedGambitSpenderId) {
+                                        ui.notifications.error("Reselect the Gambit's luck move.");
                                         return;
                                     }
+                                    // Not awaited: resolve() below must run synchronously, or Dialog#submit()'s
+                                    // immediate this.close() would settle this Promise with null first.
+                                    trySpendLuck(selectedGambitSpenderId, gambitMove);
                                 }
 
                                 resolve({
@@ -372,8 +354,28 @@ export async function renderDialog(dialog, dialogData = {}) {
                         });
 
                         html.find(".gambit-option").on("click", function () {
+                            const button = $(this);
+                            const alreadySelected = button.hasClass("selected");
                             html.find(".gambit-option").removeClass("selected");
-                            $(this).addClass("selected");
+                            selectedGambitMove = null;
+                            selectedGambitSpenderId = null;
+                            if (alreadySelected) return; // clicking the active move just deselects it
+
+                            const moveKey = button.data("stat");
+                            const actorSources = getRollableActorSources({ warnOnFail: true, hardStopOnFail: true });
+                            if (!actorSources) return;
+                            const spenders = chooseLuckSpenders(actorSources); // 0 = temp, 1 = perm, 2 = value
+                            const burnType = LUCK_MOVES[moveKey].costType;
+                            const spender = burnType === "temp" ? spenders[0]
+                                : burnType === "perm" ? spenders[1]
+                                : burnType === "value" ? spenders[2]
+                                : null;
+                            const actor = spender ? resolveActorFromSource(spender) : null;
+                            if (!canUseMove(LUCK_MOVES[moveKey], actor)) return; // canUseMove already warns
+
+                            selectedGambitMove = moveKey;
+                            selectedGambitSpenderId = spender.actorId;
+                            button.addClass("selected");
                         });
 
                         renderCustomModifierChoices();
@@ -438,7 +440,7 @@ export async function renderDialog(dialog, dialogData = {}) {
             });
         }
 
-        if (dialog === "special") {
+        case "special": {
             const specialArray = dialogData.specialArray;
             const baseStat = specialArray[0];
             const baseStatKey = typeof baseStat === "string" ? baseStat : baseStat.key;

--- a/modules/dialog.js
+++ b/modules/dialog.js
@@ -74,6 +74,7 @@ export async function renderDialog(dialog, dialogData = {}) {
 
                             const selectedGambitName = html.find(".gambit-option.selected").data("gambitName") || null;
                             // const selectedSourceUuid = html.find(".gambit-option.selected").data("sourceUuid");
+                            const selectedGambitedMove =  html.find(".gambit-option.selected").data("gambitMove")
                             const selectedActorId = html.find(".gambit-option.selected").data("actorId");
                             const selectedItemId = html.find(".gambit-option.selected").data("itemId");
 
@@ -85,6 +86,7 @@ export async function renderDialog(dialog, dialogData = {}) {
                             resolve({
                                 gambit: {
                                     name: selectedGambitName,
+                                    move: selectedGambitedMove,
                                     actorId: selectedActorId,
                                     itemId: selectedItemId
                                 },

--- a/modules/luck-moves.js
+++ b/modules/luck-moves.js
@@ -126,7 +126,7 @@ export function getLuckMoveExecutionContext(move, spenders, { isGambit = false, 
 	};
 }
 
-function canUseMove(move, actor, { costOverride = null } = {}) {
+export function canUseMove(move, actor, { costOverride = null } = {}) {
 	if (!actor) {
 		ui.notifications.warn("No valid actor available to spend Luck.");
 		return false;
@@ -196,7 +196,8 @@ export const LUCK_MOVES = {
 		costType: "gambit",
 		cost: 0,
 		timing: "anytime",
-		effect: "trigger"
+		effect: "trigger",
+		states: ["create", "execute"]
 	}
 };
 
@@ -239,14 +240,17 @@ export function chooseLuckSpenders(rollableActors) {
 		};
 		// Check if this actor has the highest of any luck value so far
 				if (!values[0] || luckStat.temp > values[0]) {
+					console.log(`highest temp: ${luckStat.temp} of ${actor.name}`)
 					values[0] = luckStat.temp;
 					spenders[0] = spenderRef;
 				}
 				if (!values[1] || luckStat.perm > values[1]) {
+					console.log(`highest perm: ${luckStat.perm} of ${actor.name}`)
 					values[1] = luckStat.perm;
 					spenders[1] = spenderRef;
 				}
 				if (!values[2] || luckStat.value > values[2]) {
+					console.log(`highest value: ${luckStat.value} of ${actor.name}`)
 					values[2] = luckStat.value;
 					spenders[2] = spenderRef;
 				}
@@ -255,8 +259,9 @@ export function chooseLuckSpenders(rollableActors) {
 	return spenders;
 }
 
-export async function trySpendLuck(actorId, action, isRefund = false, isGambit = false) { //TODO: Refund logic into own function?
+export async function trySpendLuck(actorId, action, isRefund = false, isGambit = false) { // TODO: Refund logic into own function?
 	const actor = resolveActorFromSpenderRef(actorId);
+	console.log(actor);
 	if (!actor) {
 		const displayRef = typeof actorId === "object" ? JSON.stringify(actorId) : String(actorId);
 		console.warn(`BAD6 | trySpendLuck: could not resolve luck spender "${displayRef}"`);
@@ -264,9 +269,10 @@ export async function trySpendLuck(actorId, action, isRefund = false, isGambit =
 		return false;
 	}
 	const luckStat = actor.system.attributes.stats.luck;
+	console.log(Object.values(LUCK_MOVES));
 	for (const move of Object.values(LUCK_MOVES)) {
-		if (move.name === action) {
-			const pool = move.costType === "perm" ? (luckStat.perm ?? 0) : (luckStat.temp ?? 0);
+		if (move.name === action || move.key === action) {
+			// const pool = move.costType === "perm" ? (luckStat.perm ?? 0) : (luckStat.temp ?? 0);
 			const gambitCost = isGambit ? Math.ceil(move.cost / 2) : null;
 			if (!isRefund && !canUseMove(move, actor, { costOverride: gambitCost })) {
 				return false;
@@ -288,10 +294,17 @@ export async function trySpendLuck(actorId, action, isRefund = false, isGambit =
 			}
 		}
 	}
+	// TODO: add create,execute,and reveal gambit logic
+	/*
+	If create
+		spend Math.ceil(move.cost / 2)
+	If reveal
+		refund Math.ceil(move.cost / 2)
+	*/
 
 }
 
-export async function executeLuckMove(messageId, spenders, quadrantNum, move, isGambit = false, sender = game.user.id) {
+export async function executeLuckMove(messageId, spenders, quadrantNum, move, gambitData = null, sender = game.user.id) {
 	let message = game.messages.get(messageId);
 	if (!message) return;
 	if (!LUCK_MOVES[move]) {
@@ -312,20 +325,40 @@ export async function executeLuckMove(messageId, spenders, quadrantNum, move, is
 	let moveType = LUCK_MOVES[move].key // May be edited by gambit
 	let gambitActor = null;
 	let gambitId = null; //item id
+	let isGambit = false;
+	let isRefund = false;
 
 	if (moveType == "gambit") {
-		const gambitResult = await executeGambit(messageId, quadrantNum, sender);
-		if (!gambitResult) return;
-		const [newMoveType, gambitActorId, newGambitId] = gambitResult;
-		moveType = newMoveType;
-		gambitActor = game.actors.get(gambitActorId);
-		gambitId = newGambitId; // TODO: change to this.gambitId once learned
-		isGambit = true; // TODO: Move logic so this is where isGambit is initialized
+		isGambit = true;
+		switch (gambitData?.state) { // TODO: Propogate state to actual gambit logic across system
+			case "create" : 
+				// gambitData.item
+				if (gambitData?.item) createGambit(gambitData.item.actorId, gambitData.item.gambit);
+				break;
+			case "execute" :
+				const gambitResult = await executeGambit(messageId, quadrantNum, sender);
+				if (!gambitResult) return;
+				const [newMoveType, gambitActorId, newGambitId] = gambitResult;
+				moveType = newMoveType;
+				gambitActor = game.actors.get(gambitActorId);
+				gambitId = newGambitId; // TODO: change to this.gambitId once learned
+				isRefund = true;
+				break;
+			/*
+			case "reveal" :
+				moveType = "reveal";
+				break; // logic runs during moveType
+			*/
+			default:
+				ui.notifications.error(`Unknown gambit state: ${gambitData.state}`);
+				return false;
+		}
+		
 	}
 
 	const context = getLuckMoveExecutionContext(moveType, spenders, { isGambit, checkCanUse: true });
 	if (!context.ok) {
-		ui.notifications.warn(context.reason);
+		if (move.type != "gambit") ui.notifications.warn(context.reason);
 		return;
 	}
 	const spender = context.spender;
@@ -360,7 +393,7 @@ export async function executeLuckMove(messageId, spenders, quadrantNum, move, is
 
 	// Save execution data in flags
 	if (executed) {
-		const spent = await trySpendLuck(spender, LUCK_MOVES[moveType].name, false, isGambit);
+		const spent = await trySpendLuck(spender, LUCK_MOVES[moveType].name, isRefund, isGambit);
 		if (!spent) return;
 
 		message = game.messages.get(messageId); // Refetch message to ensure we have the latest flags after move execution
@@ -418,7 +451,7 @@ export async function executeLuckMove(messageId, spenders, quadrantNum, move, is
 			await reevaluatePairRollResults(messageId, quadrantNum);
 		}
 
-		// Reveal and delete gambit document
+		// Reveal and delete gambit document (After spending for it)
 		if (isGambit) {
 			const isRevealed = revealGambit(gambitActor, gambitId);
 			if (isRevealed) gambitActor.deleteEmbeddedDocuments("gambit", [gambitId]);
@@ -455,34 +488,6 @@ function getQuadrantAdvantage(message, quadrantNum) {
 	if (Number.isFinite(own)) return Math.max(0, Math.min(3, own));
 
 	return 0;
-}
-
-
-// Returns the executed luckMove
-async function executeGambit(messageId, quadrantNum, sender) { // TODO: Clarify in all contexts that sender is an id
-	// TODO: Generate actors from quadrant num. Use linked users and highlighted if GM, and owned users if player
-	const socket = getRollerSocket();
-	if (!socket) {
-				ui.notifications.error("Socket is not ready. Cannot execute player action.");
-				return null;
-	}
-	let actors = await socket.executeAsUser("getUserActors", sender, sender) // TODO: luck-moves.js currently runs in the context of the GM, not the user
-	const isGM = !!game.users.get(sender).isGM ?? null;
-	if (isGM) {
-		const message = game.messages.get(messageId);
-		const flagData = message.getFlag("bizarre-adventures-d6", `quadrant${quadrantNum}`);
-		const actor = flagData ? resolveActorFromSource(flagData) : null;
-		console.log(actor);
-		if (actor) actors.push(actor);
-	}
-	console.log(actors);
-	// const gambitInfo = await renderDialog("gambit", {actors, quadrantNum} );
-	const gambitInfo = await executeRollerAsPlayer("renderDialog", sender, "gambit", {actors, quadrantNum} )
-	if (!gambitInfo) return null;
-	console.log(gambitInfo);
-
-
-	return [gambitInfo.gambit.move, gambitInfo.gambit.actorId, gambitInfo.gambit.itemId];
 }
 
 async function executeFeint(messageId, quadrantNum) {
@@ -561,7 +566,7 @@ async function executePersist(messageId, quadrantNum) {
 	return true;
 }
 
-export async function createGambit(actorId, gambit) { // ISOLATED FUNCTION: DOES NOT RUN THROUGH executeluckmove
+export async function createGambit(actorId, gambit) {
 	const actor = game.actors.get(actorId);
 	await actor.createEmbeddedDocuments("Item", [{
 		name: gambit.name ?? "Gambit",
@@ -574,8 +579,35 @@ export async function createGambit(actorId, gambit) { // ISOLATED FUNCTION: DOES
 	}]);
 }
 
-function revealGambit(actorId, itemId) {
-	const actor = game.actors.get(actorId)
+// Returns the executed luckMove
+async function executeGambit(messageId, quadrantNum, sender) { // TODO: Clarify in all contexts that sender is an id
+	// TODO: Generate actors from quadrant num. Use linked users and highlighted if GM, and owned users if player
+	const socket = getRollerSocket();
+	if (!socket) {
+				ui.notifications.error("Socket is not ready. Cannot execute player action.");
+				return null;
+	}
+	let actors = await socket.executeAsUser("getUserActors", sender, sender) // TODO: luck-moves.js currently runs in the context of the GM, not the user
+	const isGM = !!game.users.get(sender).isGM ?? null;
+	if (isGM) {
+		const message = game.messages.get(messageId);
+		const flagData = message.getFlag("bizarre-adventures-d6", `quadrant${quadrantNum}`);
+		const actor = flagData ? resolveActorFromSource(flagData) : null;
+		console.log(actor);
+		if (actor) actors.push(actor);
+	}
+	// console.log(actors);
+	// const gambitInfo = await renderDialog("gambit", {actors, quadrantNum} );
+	const gambitInfo = await executeRollerAsPlayer("renderDialog", sender, "gambit", {actors, quadrantNum} )
+	if (!gambitInfo) return null;
+	// console.log(gambitInfo);
+
+
+	return [gambitInfo.gambit.move, gambitInfo.gambit.actorId, gambitInfo.gambit.itemId];
+}
+
+function revealGambit(actor, itemId) {
+
 	const item = game.items.get(itemId);
 
 	const content = `

--- a/modules/luck-moves.js
+++ b/modules/luck-moves.js
@@ -561,11 +561,11 @@ async function executePersist(messageId, quadrantNum) {
 	return true;
 }
 
-export async function createGambit(actorId, gambit) {
+export async function createGambit(actorId, gambit) { // ISOLATED FUNCTION: DOES NOT RUN THROUGH executeluckmove
 	const actor = game.actors.get(actorId);
 	await actor.createEmbeddedDocuments("Item", [{
 		name: gambit.name ?? "Gambit",
-		type: "gambit", // must match your system's registered item type key
+		type: "gambit", // must match item type key
 		img: gambit.img ?? "icons/svg/dice-target.svg",
 		system: {
 			luckMove: gambit.luckMove,

--- a/modules/luck-moves.js
+++ b/modules/luck-moves.js
@@ -476,10 +476,10 @@ async function executeGambit(messageId, quadrantNum, sender) { // TODO: Clarify 
 		if (actor) actors.push(actor);
 	}
 	console.log(actors);
-	// TODO: Pull the info from the dialog
-	const gambitInfo = await renderDialog("gambit", {actors, quadrantNum} );
+	// const gambitInfo = await renderDialog("gambit", {actors, quadrantNum} );
+	const gambitInfo = await executeRollerAsPlayer("renderDialog", sender, "gambit", {actors, quadrantNum} )
 	if (!gambitInfo) return null;
-
+	console.log(gambitInfo);
 
 
 	return [gambitInfo.gambit.move, gambitInfo.gambit.actorId, gambitInfo.gambit.itemId];

--- a/modules/sockets.js
+++ b/modules/sockets.js
@@ -1,8 +1,10 @@
-import { resetQuadrant, rerenderMessage, rollAll, updateToContest, applySetPairAdvantage, applySetPairReckless, setFlag } from "./apps/bad6-roller.js";
+import { resetQuadrant, rerenderMessage, rollAll, updateToContest, applySetPairAdvantage, applySetPairReckless, setFlag, createActionMessage, createContestMessage } from "./apps/bad6-roller.js";
 import { updateQuadrant } from "./apps/roller/quadrants.js";
 import { executeLuckMove } from "./luck-moves.js";
 import { getRollableActorSources } from "./apps/roller/actors.js";
 import { withCurrentMessageMode } from "./apps/roller/chat.js";
+import { renderDialog } from "./dialog.js";
+import { applyChatButtonPermissions } from "./apps/roller/permissions.js";
 let rollerSocket = null;
 
 export function getRollerSocket() {
@@ -23,6 +25,12 @@ export function registerSockets() {
     rollerSocket.register("warnOwners", socketWarnOwners);
     rollerSocket.register("setFlag", socketSetFlag);
     rollerSocket.register("getUserActors", socketGetUserActors);
+    rollerSocket.register("createActionMessage", socketCreateActionMessage);
+    rollerSocket.register("createContestMessage", socketCreateContestMessage);
+    // rollerSocker.register("updateDisplay", socketUpdateDisplay);
+    // rollerSocket.register("applyChatButtonPermissions", socketApplyChatButtonPermissions);
+    rollerSocket.register("rerenderMessage", socketRerenderMessage);
+    rollerSocket.register("renderDialog", socketRenderDialog);
 }
 
 export async function socketApplyPreparedQuadrant(messageId, quadrantNum, preparedData) {
@@ -103,4 +111,35 @@ export async function socketSetFlag(messageId, flag, value) {
 
 export async function socketGetUserActors(sender) {
     return getRollableActorSources(sender);
+}
+
+export async function socketCreateActionMessage() {
+    return createActionMessage();
+}
+
+export async function socketCreateContestMessage() {
+    return createContestMessage();
+}
+/*
+export async function socketUpdateDisplay(messageId, html) {
+    const message = game.messages.get(messageId);
+    applyChatButtonPermissions(message, html);
+}
+*/
+/*
+export async function socketApplyChatButtonPermissions(messageId, html) {
+    console.log("[BAD6 Socket]", messageId, html);
+    const message = game.messages.get(messageId);
+    applyChatButtonPermissions(message, html);
+
+    rerenderMessage()
+}
+*/
+export async function socketRerenderMessage(messageId) {
+    const message = game.messages.get(messageId);
+    rerenderMessage(message);
+}
+
+export async function socketRenderDialog(dialog, args) {
+    return await renderDialog(dialog, args);
 }

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "bizarre-adventures-d6",
   "title": "Bizarre Adventures D6",
   "description": "A core system for the Bizarre Adventures D6 system.",
-  "version": "0.9.14.2",
+  "version": "0.9.14.3",
   "authors": [
     {
       "name": "LONYO",

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "bizarre-adventures-d6",
   "title": "Bizarre Adventures D6",
   "description": "A core system for the Bizarre Adventures D6 system.",
-  "version": "0.9.14.1",
+  "version": "0.9.14.2",
   "authors": [
     {
       "name": "LONYO",

--- a/templates/chat/action.hbs
+++ b/templates/chat/action.hbs
@@ -5,6 +5,7 @@
         Advantage: {{pairAdvantage}}
       </span>
     </div>
+    {{!--
     {{#if showReckless}}
       <div class="pair-reckless-control">
         <span class="select-stat pair-reckless-btn {{#if pairReckless}}is-active{{/if}}" role="button" tabindex="0" data-action="set-reckless" data-quadrant="{{pairQuadrantNum}}" data-tooltip="Toggle Reckless for this reaction pair">
@@ -12,6 +13,7 @@
         </span>
       </div>
     {{/if}}
+    --}}
   </div>
   {{#each quadrants}}
     <div class="action-header">{{label}}</div>

--- a/templates/dialog/gambit.hbs
+++ b/templates/dialog/gambit.hbs
@@ -7,6 +7,7 @@
                 <button class="gambit-option" 
                     type="button" 
                     data-item-id="{{this.id}}"
+                    data-gambit-move="{{this.system.luckMove}}"
                     data-gambit-name="{{this.name}}"
                     data-source-uuid="{{../sourceUuid}}"
                     data-actor-id="{{../actorId}}">


### PR DESCRIPTION
## [0.9.14.3] - 2026-8-24
- Gambit execution properly extracts the luck move
- Gambit dialog request is returned to correct sender
- It has been noted that game.messages.contents.at(-x) can expose any hidden message, overhaul of security considered
- Small patch for error emitted by action on creation
- Removed access to the reckless button
- Fixed advantage applying its visibility to first quadrant
- Fixed gambits not checking if you could afford them
- Fixed gambit dialog breaking due to async promise within confirmation dialog
- Fixed being unable to unselect a gambit
- Began standardized locations of gambit logic
- Rough patch for gambit warning in getLuckMoveExecutionContext